### PR TITLE
solves dependencies problem, endless loop 

### DIFF
--- a/src/mountall.c
+++ b/src/mountall.c
@@ -762,7 +762,7 @@ parse_zfs_list (void)
 	size_t bufsz = 4096;
 	FILE *zfs_stream;
 	const char zfs_command[] =
-	  "/sbin/zfs list -H -t filesystem -s mountpoint -o name,mountpoint,canmount";
+	    "/sbin/zfs list -H -t filesystem -s mountpoint -o name,mountpoint,canmount,readonly,atime";
 	int zfs_result;
 
 	nih_debug ("parsing ZFS list");
@@ -781,7 +781,8 @@ parse_zfs_list (void)
 	/* Read one line from the pipe into the buffer. */
 	while (fgets (buf, bufsz, zfs_stream) != NULL) {
 		char *saveptr;
-		char *zfs_name, *zfs_mountpoint, *zfs_canmount;
+		char *zfs_name, *zfs_mountpoint, *zfs_canmount, *zfs_optatime, *zfs_optronly;
+		nih_local char *zfs_mntoptions = NULL;
 
 		/* If the line didn't fit, then enlarge the buffer and retry. */
 		while ((! strchr (buf, '\n')) && (! feof (zfs_stream))) {
@@ -804,12 +805,26 @@ parse_zfs_list (void)
 		}
 
 		/* ASSERT: canmount = on | off | noauto */
-		zfs_canmount = strtok_r (NULL, "\t\n", &saveptr);
+		zfs_canmount = strtok_r (NULL, "\t", &saveptr);
 		if (! zfs_canmount || strcmp (zfs_canmount, "on")) {
 			continue;
 		}
 
-		new_mount (zfs_mountpoint, zfs_name, FALSE, "zfs", "zfsutil,nobootwait");
+		NIH_MUST (nih_strcat (&zfs_mntoptions, NULL, "zfsutil"));
+
+		/* ASSERT: readonly = on | off */
+		zfs_optronly = strtok_r (NULL, "\t", &saveptr);
+		if ( zfs_optronly && strcmp (zfs_optronly, "off") ) {
+			NIH_MUST (nih_strcat (&zfs_mntoptions, NULL, ",ro"));
+		}
+
+		/* ASSERT: atime = on | off */
+		zfs_optatime = strtok_r (NULL, "\t\n", &saveptr);
+		if ( zfs_optatime && strcmp (zfs_optatime, "on") ) {
+			NIH_MUST (nih_strcat (&zfs_mntoptions, NULL, ",noatime"));
+		}
+
+		new_mount (zfs_mountpoint, zfs_name, FALSE, "zfs", zfs_mntoptions);
 	}
 
 	zfs_result = pclose (zfs_stream);

--- a/src/mountall.c
+++ b/src/mountall.c
@@ -761,71 +761,56 @@ parse_zfs_list (void)
 	nih_local char *buf = NULL;
 	size_t bufsz = 4096;
 	FILE *zfs_stream;
-        const char zfs_command[] =
-          "/sbin/zfs list -H -t filesystem -s mountpoint -o name,mountpoint,canmount,readonly,atime";
-        int zfs_result;
+	const char zfs_command[] =
+	  "/sbin/zfs list -H -t filesystem -s mountpoint -o name,mountpoint,canmount";
+	int zfs_result;
 
-        nih_debug ("parsing ZFS list");
+	nih_debug ("parsing ZFS list");
 
-        fflush (stdout);
-        fflush (stderr);
-        zfs_stream = popen (zfs_command, "r");
+	fflush (stdout);
+	fflush (stderr);
+	zfs_stream = popen (zfs_command, "r");
 
-        if (zfs_stream == NULL) {
-                nih_debug ("popen /sbin/zfs: %s", strerror (errno));
-                return;
-        }
+	if (zfs_stream == NULL) {
+		nih_debug ("popen /sbin/zfs: %s", strerror (errno));
+		return;
+	}
 
-        buf = NIH_MUST (nih_alloc (NULL, bufsz));
+	buf = NIH_MUST (nih_alloc (NULL, bufsz));
 
-        /* Read one line from the pipe into the buffer. */
-        while (fgets (buf, bufsz, zfs_stream) != NULL) {
-                char *saveptr;
-                char *zfs_name, *zfs_mountpoint, *zfs_canmount, *zfs_optatime, *zfs_optronly;
-                nih_local char *zfs_mntoptions = NULL;
+	/* Read one line from the pipe into the buffer. */
+	while (fgets (buf, bufsz, zfs_stream) != NULL) {
+		char *saveptr;
+		char *zfs_name, *zfs_mountpoint, *zfs_canmount;
 
-                /* If the line didn't fit, then enlarge the buffer and retry. */
-                while ((! strchr (buf, '\n')) && (! feof (zfs_stream))) {
-                        buf = NIH_MUST (nih_realloc (buf, NULL, bufsz + 4096));
-                        if (! fgets (buf + bufsz - 1, 4097, zfs_stream)) {
-                                break;
-                        }
-                        bufsz += 4096;
-                }
+		/* If the line didn't fit, then enlarge the buffer and retry. */
+		while ((! strchr (buf, '\n')) && (! feof (zfs_stream))) {
+			buf = NIH_MUST (nih_realloc (buf, NULL, bufsz + 4096));
+			if (! fgets (buf + bufsz - 1, 4097, zfs_stream)) {
+				break;
+			}
+			bufsz += 4096;
+		}
 
-                zfs_name = strtok_r (buf, "\t", &saveptr);
-                if (! zfs_name) {
-                        continue;
-                }
+		zfs_name = strtok_r (buf, "\t", &saveptr);
+		if (! zfs_name) {
+			continue;
+		}
 
-                /* ASSERT: mountpoint[0] = '/' OR mountpoint = none | legacy */
-                zfs_mountpoint = strtok_r (NULL, "\t", &saveptr);
-                if (! zfs_mountpoint || zfs_mountpoint[0] != '/') {
-                        continue;
-                }
+		/* ASSERT: mountpoint[0] = '/' OR mountpoint = none | legacy */
+		zfs_mountpoint = strtok_r (NULL, "\t", &saveptr);
+		if (! zfs_mountpoint || zfs_mountpoint[0] != '/') {
+			continue;
+		}
 
-                /* ASSERT: canmount = on | off | noauto */
-                zfs_canmount = strtok_r (NULL, "\t", &saveptr);
-                if (! zfs_canmount || strcmp (zfs_canmount, "on")) {
-                        continue;
-                }
+		/* ASSERT: canmount = on | off | noauto */
+		zfs_canmount = strtok_r (NULL, "\t\n", &saveptr);
+		if (! zfs_canmount || strcmp (zfs_canmount, "on")) {
+			continue;
+		}
 
-                NIH_MUST (nih_strcat (&zfs_mntoptions, NULL, "zfsutil"));
-
-                /* ASSERT: readonly = on | off */
-                zfs_optronly = strtok_r (NULL, "\t", &saveptr);
-                if ( zfs_optronly && strcmp (zfs_optronly, "off") ) {
-                        NIH_MUST (nih_strcat (&zfs_mntoptions, NULL, ",ro"));
-                }
-
-                /* ASSERT: atime = on | off */
-                zfs_optatime = strtok_r (NULL, "\t\n", &saveptr);
-                if ( zfs_optatime && strcmp (zfs_optatime, "on") ) {
-                        NIH_MUST (nih_strcat (&zfs_mntoptions, NULL, ",noatime"));
-                }
-
-                new_mount (zfs_mountpoint, zfs_name, FALSE, "zfs", zfs_mntoptions);
-        }
+		new_mount (zfs_mountpoint, zfs_name, FALSE, "zfs", "zfsutil,nobootwait");
+	}
 
 	zfs_result = pclose (zfs_stream);
 

--- a/src/mountall.c
+++ b/src/mountall.c
@@ -761,56 +761,71 @@ parse_zfs_list (void)
 	nih_local char *buf = NULL;
 	size_t bufsz = 4096;
 	FILE *zfs_stream;
-	const char zfs_command[] =
-	  "/sbin/zfs list -H -t filesystem -s mountpoint -o name,mountpoint,canmount";
-	int zfs_result;
+        const char zfs_command[] =
+          "/sbin/zfs list -H -t filesystem -s mountpoint -o name,mountpoint,canmount,readonly,atime";
+        int zfs_result;
 
-	nih_debug ("parsing ZFS list");
+        nih_debug ("parsing ZFS list");
 
-	fflush (stdout);
-	fflush (stderr);
-	zfs_stream = popen (zfs_command, "r");
+        fflush (stdout);
+        fflush (stderr);
+        zfs_stream = popen (zfs_command, "r");
 
-	if (zfs_stream == NULL) {
-		nih_debug ("popen /sbin/zfs: %s", strerror (errno));
-		return;
-	}
+        if (zfs_stream == NULL) {
+                nih_debug ("popen /sbin/zfs: %s", strerror (errno));
+                return;
+        }
 
-	buf = NIH_MUST (nih_alloc (NULL, bufsz));
+        buf = NIH_MUST (nih_alloc (NULL, bufsz));
 
-	/* Read one line from the pipe into the buffer. */
-	while (fgets (buf, bufsz, zfs_stream) != NULL) {
-		char *saveptr;
-		char *zfs_name, *zfs_mountpoint, *zfs_canmount;
+        /* Read one line from the pipe into the buffer. */
+        while (fgets (buf, bufsz, zfs_stream) != NULL) {
+                char *saveptr;
+                char *zfs_name, *zfs_mountpoint, *zfs_canmount, *zfs_optatime, *zfs_optronly;
+                nih_local char *zfs_mntoptions = NULL;
 
-		/* If the line didn't fit, then enlarge the buffer and retry. */
-		while ((! strchr (buf, '\n')) && (! feof (zfs_stream))) {
-			buf = NIH_MUST (nih_realloc (buf, NULL, bufsz + 4096));
-			if (! fgets (buf + bufsz - 1, 4097, zfs_stream)) {
-				break;
-			}
-			bufsz += 4096;
-		}
+                /* If the line didn't fit, then enlarge the buffer and retry. */
+                while ((! strchr (buf, '\n')) && (! feof (zfs_stream))) {
+                        buf = NIH_MUST (nih_realloc (buf, NULL, bufsz + 4096));
+                        if (! fgets (buf + bufsz - 1, 4097, zfs_stream)) {
+                                break;
+                        }
+                        bufsz += 4096;
+                }
 
-		zfs_name = strtok_r (buf, "\t", &saveptr);
-		if (! zfs_name) {
-			continue;
-		}
+                zfs_name = strtok_r (buf, "\t", &saveptr);
+                if (! zfs_name) {
+                        continue;
+                }
 
-		/* ASSERT: mountpoint[0] = '/' OR mountpoint = none | legacy */
-		zfs_mountpoint = strtok_r (NULL, "\t", &saveptr);
-		if (! zfs_mountpoint || zfs_mountpoint[0] != '/') {
-			continue;
-		}
+                /* ASSERT: mountpoint[0] = '/' OR mountpoint = none | legacy */
+                zfs_mountpoint = strtok_r (NULL, "\t", &saveptr);
+                if (! zfs_mountpoint || zfs_mountpoint[0] != '/') {
+                        continue;
+                }
 
-		/* ASSERT: canmount = on | off | noauto */
-		zfs_canmount = strtok_r (NULL, "\t\n", &saveptr);
-		if (! zfs_canmount || strcmp (zfs_canmount, "on")) {
-			continue;
-		}
+                /* ASSERT: canmount = on | off | noauto */
+                zfs_canmount = strtok_r (NULL, "\t", &saveptr);
+                if (! zfs_canmount || strcmp (zfs_canmount, "on")) {
+                        continue;
+                }
 
-		new_mount (zfs_mountpoint, zfs_name, FALSE, "zfs", "zfsutil,nobootwait");
-	}
+                NIH_MUST (nih_strcat (&zfs_mntoptions, NULL, "zfsutil"));
+
+                /* ASSERT: readonly = on | off */
+                zfs_optronly = strtok_r (NULL, "\t", &saveptr);
+                if ( zfs_optronly && strcmp (zfs_optronly, "off") ) {
+                        NIH_MUST (nih_strcat (&zfs_mntoptions, NULL, ",ro"));
+                }
+
+                /* ASSERT: atime = on | off */
+                zfs_optatime = strtok_r (NULL, "\t\n", &saveptr);
+                if ( zfs_optatime && strcmp (zfs_optatime, "on") ) {
+                        NIH_MUST (nih_strcat (&zfs_mntoptions, NULL, ",noatime"));
+                }
+
+                new_mount (zfs_mountpoint, zfs_name, FALSE, "zfs", zfs_mntoptions);
+        }
 
 	zfs_result = pclose (zfs_stream);
 

--- a/src/mountall.c
+++ b/src/mountall.c
@@ -762,7 +762,7 @@ parse_zfs_list (void)
 	size_t bufsz = 4096;
 	FILE *zfs_stream;
 	const char zfs_command[] =
-	  "/sbin/zfs list -H -t filesystem -o name,mountpoint,canmount";
+	  "/sbin/zfs list -H -t filesystem -s mountpoint -o name,mountpoint,canmount";
 	int zfs_result;
 
 	nih_debug ("parsing ZFS list");


### PR DESCRIPTION
I suppose this needs fixing in mountall original code, but for the time being.

specific case like this:

fs                   mountpoint
zfs                  /zfs
zfs/home             /home
zfs/home/1           /zfs/test/1
zfs/test             /zfs/test

mountall ended up in an endless loop, waiting for dependencies. if mounts are read ordered by mount points, it's ok. 

at line 1329 in procedure mount_policy is a test for kernel filesystems (nodev) which puts parent device (prior processed entry) into dependencies, creating a loop in this example.
